### PR TITLE
Make possible to re open a stream

### DIFF
--- a/FlexibleStreamHandling/FileIOStream.cs
+++ b/FlexibleStreamHandling/FileIOStream.cs
@@ -5,8 +5,8 @@ namespace FlexibleStreamHandling
     public class FileIOStream : FlexibleStream
     {
         private readonly string _filePath;
-        private readonly FileMode _fileMode;
-        private readonly FileAccess _fileAccess;
+        private FileMode _fileMode;
+        private FileAccess _fileAccess;
         private FileStream _fileStream;
         public bool DeleteWhenReady { get; set; }
 
@@ -43,6 +43,16 @@ namespace FlexibleStreamHandling
         protected override void CloseStream()
         {
             _fileStream?.Close();
+        }
+
+        public override void ReOpenAs(FileMode fileMode, FileAccess fileAccess)
+        {
+            _fileMode = fileMode;
+            _fileAccess = fileAccess;
+            Dispose();
+            _fileStream = null;
+            Disposed = false;
+
         }
     }
 }

--- a/FlexibleStreamHandling/FlexibleStream.cs
+++ b/FlexibleStreamHandling/FlexibleStream.cs
@@ -68,6 +68,8 @@ namespace FlexibleStreamHandling
 
         protected abstract void CloseStream();
 
+        public abstract void ReOpenAs(FileMode fileMode, FileAccess fileAccess);
+
         public void Dispose()
         {
             Dispose(true);

--- a/FlexibleStreamHandling/StringReader.cs
+++ b/FlexibleStreamHandling/StringReader.cs
@@ -29,5 +29,12 @@ namespace FlexibleStreamHandling
         {
             Stream.Close();
         }
+
+        public override void ReOpenAs(FileMode fileMode, FileAccess fileAccess)
+        {
+            Dispose();
+            _memoryStream = null;
+            Disposed = false;
+        }
     }
 }


### PR DESCRIPTION
The user case: within a method, 1) entire file is read into local
variable, 2) process the contents, 3) write to the file, replace it's
contents with the processed contents. In this case the stream has to be
opened twice within a method, first time with read file access and
second time with write.

Method ReOpenAs disposes the current stream and open it again with new
parameters.